### PR TITLE
fix: messageTaunt no longer returns %s, switch to using ChatHandler

### DIFF
--- a/src/npc_gambler.cpp
+++ b/src/npc_gambler.cpp
@@ -218,7 +218,7 @@ public:
         {
             std::ostringstream messageTaunt;
             messageTaunt << "Whadda we have here? A high-roller eh? Step right up " << player->GetName() << "!";
-            player->GetSession()->SendNotification("%s", messageTaunt.str().c_str());
+            ChatHandler(player->GetSession()).SendNotification(messageTaunt.str().c_str());
         }
 
         // Reset # of bets placed


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- messageTaunt was returning `%s` in game, instead of the taunt
- in newer commits of AzerothCore, mod-npc-gambler wouldn't compile due to SendNotification not being in WorldSession.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes #21

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- For the messageTaunt, walk up to Loita with more than 5k gold, and you'll get %s in the error text instead of the taunt.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. For the messageTaunt, walk up to Loita with more than 5k gold, and you'll get a proper message taunt.
